### PR TITLE
Enable binary acceptance test driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,13 @@ language: go
 go:
   - "1.11.x"
 env:
-  - GO111MODULE=on GOFLAGS=-mod=vendor
+  - GO111MODULE=on GOFLAGS=-mod=vendor TF_VERSION=0.12.24
+
+before_script:
+  - curl -fSL "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip" -o terraform.zip
+  - sudo unzip terraform.zip -d /opt/terraform
+  - sudo ln -s /opt/terraform/terraform /usr/bin/terraform
+  - rm -f terraform.zip
 
 install:
 # This script is used by the Travis build to install a cookie for
@@ -17,6 +23,7 @@ install:
 
 script:
 - make test
+- make testacc
 - make vet
 - make website-test
 

--- a/http/data_source_test.go
+++ b/http/data_source_test.go
@@ -207,24 +207,6 @@ func TestDataSource_utf16(t *testing.T) {
 	})
 }
 
-const testDataSourceConfig_error = `
-data "http" "http_test" {
-
-}
-`
-
-func TestDataSource_compileError(t *testing.T) {
-	resource.UnitTest(t, resource.TestCase{
-		Providers: testProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testDataSourceConfig_error,
-				ExpectError: regexp.MustCompile("The argument \"url\" is required, but no definition was found."),
-			},
-		},
-	})
-}
-
 func setUpMockHttpServer() *TestHttpMock {
 	Server := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/http/provider_test.go
+++ b/http/provider_test.go
@@ -3,6 +3,8 @@ package http
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -15,4 +17,9 @@ func TestProvider(t *testing.T) {
 	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
+}
+
+func TestMain(m *testing.M) {
+	acctest.UseBinaryDriver("http", Provider)
+	resource.TestMain(m)
 }


### PR DESCRIPTION
This PR enables the new binary acceptance test driver available from v1.7.0 of the plugin SDK.

Provider acceptance tests now run real `terraform` CLI commands under the hood. The test API remains the same, and there should be no other changes to test results or output. Please see https://github.com/hashicorp/terraform-plugin-sdk/pull/262 for more details.