### PR TITLE
tree-wide: fix references to the terraform-providers organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ NOTES:
 
 IMPROVEMENTS:
 
-* Switch to v1.7.0 of the standalone plugin SDK ([#35](https://github.com/terraform-providers/terraform-provider-http/issues/35))
-* Added response_headers to datasource ([#31](https://github.com/terraform-providers/terraform-provider-http/issues/31))
+* Switch to v1.7.0 of the standalone plugin SDK ([#35](https://github.com/hashicorp/terraform-provider-http/issues/35))
+* Added response_headers to datasource ([#31](https://github.com/hashicorp/terraform-provider-http/issues/31))
 
 BUG FIXES:
 
-* Fix request error message to include the `err` and not just url ([#26](https://github.com/terraform-providers/terraform-provider-http/issues/26))
+* Fix request error message to include the `err` and not just url ([#26](https://github.com/hashicorp/terraform-provider-http/issues/26))
 
 ## 1.1.1 (May 01, 2019)
 
@@ -27,11 +27,11 @@ IMPROVEMENTS:
 
 ## 1.0.1 (January 03, 2018)
 
-* Allow `charset` argument on `Content-Type` ([#5](https://github.com/terraform-providers/terraform-provider-http/issues/5))
+* Allow `charset` argument on `Content-Type` ([#5](https://github.com/hashicorp/terraform-provider-http/issues/5))
 
 ## 1.0.0 (September 14, 2017)
 
-* add content type for ADFS FederationMetadata.xml ([#4](https://github.com/terraform-providers/terraform-provider-http/issues/4))
+* add content type for ADFS FederationMetadata.xml ([#4](https://github.com/hashicorp/terraform-provider-http/issues/4))
 
 ## 0.1.0 (June 20, 2017)
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-http`
+Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-http`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-http
+$ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
+$ git clone git@github.com:hashicorp/terraform-provider-http
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-http
+$ cd $GOPATH/src/github.com/hashicorp/terraform-provider-http
 $ make build
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-http
+module github.com/hashicorp/terraform-provider-http
 
 require (
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-http/http"
+	"github.com/hashicorp/terraform-provider-http/http"
 )
 
 func main() {

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,7 +24,7 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-http\/issues"
+PROVIDER_URL="https:\/\/github.com\/hashicorp\/terraform-provider-http\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 


### PR DESCRIPTION
`terraform-provider-http` has been moved to the `hashicorp`
organization.