### PR TITLE
Fix link to http provider documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ make build
 
 Using the provider
 ----------------------
-see <https://www.terraform.io/docs/providers/http/data_source.html>
+see <https://www.terraform.io/docs/providers/http/>
 
 Developing the Provider
 ---------------------------


### PR DESCRIPTION
Current link was returning a 404