### PR TITLE
generic-added request method and body for post requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
-## 2.0.0 (Unreleased)
+## 2.0.0 (October 14, 2020)
 
 Binary releases of this provider will now include the linux-arm64 platform.
 
 BREAKING CHANGES:
 
-* Upgrade to version 2 of the Terraform Plugin SDK, which drops support for Terraform 0.11. This provider will continue to work as expected for users of Terraform 0.11, which will not download the new version. [GH-47]
+* Upgrade to version 2 of the Terraform Plugin SDK, which drops support for Terraform 0.11. This provider will continue to work as expected for users of Terraform 0.11, which will not download the new version. ([#47](https://github.com/terraform-providers/terraform-provider-http/issues/47))
 
 IMPROVEMENTS:
 
-* Relaxed error on non-text `Content-Type` headers to be a warning instead [GH-50]
+* Relaxed error on non-text `Content-Type` headers to be a warning instead ([#50](https://github.com/terraform-providers/terraform-provider-http/issues/50))
 
 BUG FIXES:
 
-* Modified some of the documentation to work a bit better in the registry [GH-42]
-* Allowed the `us-ascii` charset in addition to `utf-8` [GH-43]
+* Modified some of the documentation to work a bit better in the registry ([#42](https://github.com/terraform-providers/terraform-provider-http/issues/42))
+* Allowed the `us-ascii` charset in addition to `utf-8` ([#43](https://github.com/terraform-providers/terraform-provider-http/issues/43))
 
 ## 1.2.0 (March 17, 2020)
 

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `request_headers` - (Optional) A map of strings representing additional HTTP
 * `request_method` - (Optional) Method to use to perform request default is GET
-* `request_body` - (Optional) Body of request to send
+* `request_body` - (Optional) Body of request to send in request
   headers to include in the request.
 
 ## Attributes Reference

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -40,6 +40,8 @@ The following arguments are supported:
   a `200 OK` response and a `text/*` or `application/json` Content-Type.
 
 * `request_headers` - (Optional) A map of strings representing additional HTTP
+* `request_method` - (Optional) Method to use to perform request default is GET
+* `request_body` - (Optional) Body of request to send
   headers to include in the request.
 
 ## Attributes Reference

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module github.com/terraform-providers/terraform-provider-http
 
-require github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.3
+require (
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.3
+	google.golang.org/appengine v1.6.6 // indirect
+)
 
 go 1.13

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -34,6 +35,25 @@ func dataSource() *schema.Resource {
 				},
 			},
 
+			"request_method": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Default:     "GET",
+				Description: "Request method type to call the API with.",
+			},
+
+			"request_body": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Default: nil,
+			},
+
 			"body": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -56,10 +76,12 @@ func dataSource() *schema.Resource {
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
 	url := d.Get("url").(string)
 	headers := d.Get("request_headers").(map[string]interface{})
+	method := d.Get("request_method").(string)
+	body := []byte(d.Get("request_body").(string))
 
 	client := &http.Client{}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewBuffer(body))
 	if err != nil {
 		return append(diags, diag.Errorf("Error creating request: %s", err)...)
 	}


### PR DESCRIPTION
This adds the capability of providing the following to the data provider for http:
request_method
request_body
