### PR TITLE
Allow mime sub-type for JSON API

### DIFF
--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -125,6 +125,7 @@ func isContentTypeText(contentType string) bool {
 		regexp.MustCompile("^text/.+"),
 		regexp.MustCompile("^application/json$"),
 		regexp.MustCompile("^application/samlmetadata\\+xml"),
+		regexp.MustCompile("^application/vnd.api\\+json"),
 	}
 
 	for _, r := range allowedContentTypes {


### PR DESCRIPTION
Add support for the [JSON API](https://jsonapi.org/) mime subtype of type `application` as defined by the [IANA document](https://www.iana.org/assignments/media-types/application/vnd.api+json).  It is JSON and therefore non-binary as required.