### PR TITLE
add optional timeout to client

### DIFF
--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -42,6 +42,8 @@ The following arguments are supported:
 * `request_headers` - (Optional) A map of strings representing additional HTTP
   headers to include in the request.
 
+* `timeout` - (Optional) Client timeout in seconds
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -34,6 +35,14 @@ func dataSource() *schema.Resource {
 				},
 			},
 
+			"timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+
 			"body": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -56,8 +65,11 @@ func dataSource() *schema.Resource {
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
 	url := d.Get("url").(string)
 	headers := d.Get("request_headers").(map[string]interface{})
+	timeout := d.Get("timeout").(int)
 
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: time.Duration(timeout) * time.Second, // defaults to 0
+	}
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
This adds a new argument called `timeout` to allow setting of the client timeout.