### PR TITLE
Migrate most GitHub HashiBot behaviors to GitHub Actions

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -1,0 +1,4 @@
+bug:
+  - 'panic:'
+crash:
+  - 'panic:'

--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -1,0 +1,6 @@
+dependencies:
+  - .github/dependabot.yml
+  - go.mod
+  - go.sum
+documentation:
+  - docs/**/*

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -1,0 +1,15 @@
+name: Issue Comment Created Triage
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  issue_comment_triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            stale
+            waiting-reply

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -1,0 +1,15 @@
+name: Issue Opened Triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  issue_triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: github/issue-labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/labeler-issue-triage.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Triage"
+
+on: [pull_request_target]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        configuration-path: .github/labeler-pull-request-triage.yml
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,13 +1,3 @@
-behavior "regexp_issue_labeler" "panic_label" {
-    regexp = "panic:"
-    labels = ["crash", "bug"]
-}
-
-behavior "remove_labels_on_reply" "remove_stale" {
-    labels = ["waiting-response", "stale"]
-    only_non_maintainers = true
-}
-
 behavior "pull_request_size_labeler" "size" {
     label_prefix = "size/"
     label_map = {
@@ -35,12 +25,5 @@ behavior "pull_request_size_labeler" "size" {
             from = 1001
             to = 0
         }
-    }
-}
-
-behavior "pull_request_path_labeler" "cross_provider_labels" {
-    label_map = {
-        "documentation" = ["docs/**/*"]
-        "dependencies" = ["vendor/**/*"]
     }
 }


### PR DESCRIPTION
GitHub HashiBot is being deprecated and this replaces behaviors with equivalent workflows in GitHub Actions. The `pull_request_size_labeler` behavior will be handled once an upstream enhancement is merged (or if we decide to use a fork with the change).