### PR TITLE
Support for using HTTP methods other than GET and sending data in request body

### DIFF
--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -44,6 +44,8 @@ The following arguments are supported:
 
 * `method` - (Optional) Method name. Default value is `GET`.
 
+* `request_body` - (Optional) Request body to send. Default is none.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -42,6 +42,8 @@ The following arguments are supported:
 * `request_headers` - (Optional) A map of strings representing additional HTTP
   headers to include in the request.
 
+* `method` - (Optional) Method name. Default value is `GET`.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -43,6 +43,14 @@ func dataSource() *schema.Resource {
 				},
 			},
 
+			"request_body": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
 			"body": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -66,10 +74,12 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{
 	url := d.Get("url").(string)
 	headers := d.Get("request_headers").(map[string]interface{})
 	method := d.Get("method").(string)
+	request_body := d.Get("request_body").(string)
+	body_reader := strings.NewReader(request_body)
 
 	client := &http.Client{}
 
-	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	req, err := http.NewRequestWithContext(ctx, method, url, body_reader)
 	if err != nil {
 		return append(diags, diag.Errorf("Error creating request: %s", err)...)
 	}

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -26,6 +26,15 @@ func dataSource() *schema.Resource {
 				},
 			},
 
+			"method": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Default: "GET",
+			},
+
 			"request_headers": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -56,10 +65,11 @@ func dataSource() *schema.Resource {
 func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
 	url := d.Get("url").(string)
 	headers := d.Get("request_headers").(map[string]interface{})
+	method := d.Get("method").(string)
 
 	client := &http.Client{}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
 	if err != nil {
 		return append(diags, diag.Errorf("Error creating request: %s", err)...)
 	}


### PR DESCRIPTION
This PR adds support for using HTTP methods other than GET and sending data in request body.
Makes http datasource useful for interacting with complex APIs.
Please review.