### PR TITLE
Allow XML responses

### DIFF
--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -125,6 +125,7 @@ func isContentTypeText(contentType string) bool {
 		regexp.MustCompile("^text/.+"),
 		regexp.MustCompile("^application/json$"),
 		regexp.MustCompile("^application/samlmetadata\\+xml"),
+		regexp.MustCompile("^application/xml$"),
 	}
 
 	for _, r := range allowedContentTypes {


### PR DESCRIPTION
fixes #99 

Notes:
- We already have support for [SAML metadata (xml)](https://github.com/hashicorp/terraform-provider-http/blob/202f46f19c1d56af94e3d2bca1ca994186b4feb6/internal/provider/data_source.go#L127).

- https://github.com/hashicorp/terraform-provider-http/blob/202f46f19c1d56af94e3d2bca1ca994186b4feb6/internal/provider/data_source.go#L114-L116