### PR TITLE
Allow accepting additional StatusCodes with custom fallback response

### DIFF
--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -54,6 +54,8 @@ data "http" "example" {
 
 ### Optional
 
+- `allowed_errors` (Set of Number) A set of integers representing non-200 HTTP status codes that are acceptable responses.
+- `error_response` (String) A fallback response value to use as `body` if the response status is a code specified in `allowed_errors`. If not defined, the actual response body is still returned.
 - `request_headers` (Map of String) A map of request header field names and values.
 
 ### Read-Only

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -54,8 +54,8 @@ data "http" "example" {
 
 ### Optional
 
-- `allowed_errors` (Set of Number) A set of integers representing non-200 HTTP status codes that are acceptable responses.
-- `error_response` (String) A fallback response value to use as `body` if the response status is a code specified in `allowed_errors`. If not defined, the actual response body is still returned.
+- `fallback_on_status` (Set of Number) A set of integers representing HTTP status codes that are acceptable responses, and may substitute the `fallback_response` if received.
+- `fallback_response` (String) A fallback response value to use as `body` if the response status is a code specified in `fallback_on_status`. If not defined, the actual response body is still returned.
 - `request_headers` (Map of String) A map of request header field names and values.
 
 ### Read-Only


### PR DESCRIPTION
Allow specifying HTTP error codes that should be accepted instead of producing an error (e.g. 404, 500, etc).
You can configure a default/fallback response body to use if the errors are encountered, or just use the real response.
If you specify 200 as an allowed error, you can also use this to mock out the response; potential footgun, but could also be useful in some testing scenarios.

See #107, also applicable to #41.