### PR TITLE
Allow optionally specifying HTTP request method and body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
+## 3.1.0 (unreleased)
+
+ENHANCEMENTS:
+
+* data-source/http: Allow optionally specifying HTTP request method and body ([#21](https://github.com/hashicorp/terraform-provider-http/issues/21)).
+
 ## 3.0.1 (July 27, 2022)
 
 BUG FIXES
 
 * data-source/http: Reinstated previously deprecated and removed `body` attribute ([#166](https://github.com/hashicorp/terraform-provider-http/pull/166)).
-
 
 ## 3.0.0 (July 27, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ BUG FIXES
 
 * data-source/http: Reinstated previously deprecated and removed `body` attribute ([#166](https://github.com/hashicorp/terraform-provider-http/pull/166)).
 
+
 ## 3.0.0 (July 27, 2022)
 
 NOTES:

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -127,6 +127,8 @@ resource "null_resource" "example" {
 
 ### Optional
 
+- `method` (String) The HTTP Method for the request. Allowed methods are a subset of methods defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3) namely, `GET`, `POST`, `PUT`, `PATCH`, `DELETE` and `HEAD`.
+- `request_body` (String) The request body as a string.
 - `request_headers` (Map of String) A map of request header field names and values.
 
 ### Read-Only

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -127,14 +127,14 @@ resource "null_resource" "example" {
 
 ### Optional
 
-- `method` (String) The HTTP Method for the request. Allowed methods are a subset of methods defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3) namely, `GET`, `POST`, `PUT`, `PATCH`, `DELETE` and `HEAD`.
+- `method` (String) The HTTP Method for the request. Allowed methods are a subset of methods defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3) namely, `GET`, `HEAD`, and `POST`. `POST` support is only intended for read-only URLs, such as submitting a search.
 - `request_body` (String) The request body as a string.
 - `request_headers` (Map of String) A map of request header field names and values.
 
 ### Read-Only
 
 - `body` (String, Deprecated) The response body returned as a string. **NOTE**: This is deprecated, use `response_body` instead.
-- `id` (String) The ID of this resource.
+- `id` (String) The URL used for the request.
 - `response_body` (String) The response body returned as a string.
 - `response_headers` (Map of String) A map of response header field names and values. Duplicate headers are concatenated according to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).
 - `status_code` (Number) The HTTP response status code.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v0.10.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.4.0
 	github.com/hashicorp/terraform-plugin-go v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.20.0
 )
@@ -57,13 +58,13 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
-	github.com/vmihailenco/tagparser v0.1.1 // indirect
+	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
-	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
-	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b // indirect
+	golang.org/x/net v0.0.0-20220708220712-1185a9018129 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect
 	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/hashicorp/terraform-plugin-docs v0.13.0 h1:6e+VIWsVGb6jYJewfzq2ok2smP
 github.com/hashicorp/terraform-plugin-docs v0.13.0/go.mod h1:W0oCmHAjIlTHBbvtppWHe8fLfZ2BznQbuv8+UD8OucQ=
 github.com/hashicorp/terraform-plugin-framework v0.10.0 h1:LGYcnvNdVaZA1ZHe53BHLVjaaGs7HTiq6+9Js29stL4=
 github.com/hashicorp/terraform-plugin-framework v0.10.0/go.mod h1:CK7Opzukfu/2CPJs+HzUdfHrFlp+ZIQeSxjF0x8k464=
+github.com/hashicorp/terraform-plugin-framework-validators v0.4.0 h1:GVX4gDFdtFZi/E4DjvPmRDf5zBLFAHi8M7Qzehgov+Q=
+github.com/hashicorp/terraform-plugin-framework-validators v0.4.0/go.mod h1:hkGjFzftzT/HRe1It0e8//tGZ3j18PedTq4hHS8NJ/Q=
 github.com/hashicorp/terraform-plugin-go v0.12.0/go.mod h1:kwhmaWHNDvT1B3QiSJdAtrB/D4RaKSY/v3r2BuoWK4M=
 github.com/hashicorp/terraform-plugin-go v0.13.0 h1:Zm+o91HUOcTLotaEu3X2jV/6wNi6f09gkZwGg/MDvCk=
 github.com/hashicorp/terraform-plugin-go v0.13.0/go.mod h1:NYGFEM9GeRdSl52txue3RcBDFt2tufaqS22iURP8Bxs=
@@ -266,8 +268,9 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvCazn8G65U=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
-github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vbd1qPqc=
+github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -313,8 +316,9 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220708220712-1185a9018129 h1:vucSRfWwTsoXro7P+3Cjlr6flUMtzCwzlvkxEQtHHB0=
+golang.org/x/net v0.0.0-20220708220712-1185a9018129/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -346,9 +350,12 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/FiaizQEK5Gu4Bq4JE8=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -370,8 +377,9 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
-google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
+google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -37,7 +37,7 @@ your control should be treated as untrustworthy.`,
 
 		Attributes: map[string]tfsdk.Attribute{
 			"id": {
-				Description: "The ID of this resource.",
+				Description: "The URL used for the request.",
 				Type:        types.StringType,
 				Computed:    true,
 			},

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -51,16 +51,13 @@ your control should be treated as untrustworthy.`,
 			"method": {
 				Description: "The HTTP Method for the request. " +
 					"Allowed methods are a subset of methods defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3) namely, " +
-					"`GET`, `POST`, `PUT`, `PATCH`, `DELETE` and `HEAD`.",
+					"`GET`, `HEAD`, and `POST`. `POST` support is only intended for read-only URLs, such as submitting a search.",
 				Type:     types.StringType,
 				Optional: true,
 				Validators: []tfsdk.AttributeValidator{
 					stringvalidator.OneOf([]string{
 						http.MethodGet,
 						http.MethodPost,
-						http.MethodPut,
-						http.MethodPatch,
-						http.MethodDelete,
 						http.MethodHead,
 					}...),
 				},

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,10 +36,34 @@ the server certificate's chain of trust. Data retrieved from servers not under
 your control should be treated as untrustworthy.`,
 
 		Attributes: map[string]tfsdk.Attribute{
+			"id": {
+				Description: "The ID of this resource.",
+				Type:        types.StringType,
+				Computed:    true,
+			},
+
 			"url": {
 				Description: "The URL for the request. Supported schemes are `http` and `https`.",
 				Type:        types.StringType,
 				Required:    true,
+			},
+
+			"method": {
+				Description: "The HTTP Method for the request. " +
+					"Allowed methods are a subset of methods defined in [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3) namely, " +
+					"`GET`, `POST`, `PUT`, `PATCH`, `DELETE` and `HEAD`.",
+				Type:     types.StringType,
+				Optional: true,
+				Validators: []tfsdk.AttributeValidator{
+					stringvalidator.OneOf([]string{
+						http.MethodGet,
+						http.MethodPost,
+						http.MethodPut,
+						http.MethodPatch,
+						http.MethodDelete,
+						http.MethodHead,
+					}...),
+				},
 			},
 
 			"request_headers": {
@@ -47,6 +72,12 @@ your control should be treated as untrustworthy.`,
 					ElemType: types.StringType,
 				},
 				Optional: true,
+			},
+
+			"request_body": {
+				Description: "The request body as a string.",
+				Type:        types.StringType,
+				Optional:    true,
 			},
 
 			"response_body": {
@@ -77,12 +108,6 @@ your control should be treated as untrustworthy.`,
 				Type:        types.Int64Type,
 				Computed:    true,
 			},
-
-			"id": {
-				Description: "The ID of this resource.",
-				Type:        types.StringType,
-				Computed:    true,
-			},
 		},
 	}, nil
 }
@@ -104,11 +129,17 @@ func (d *httpDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourceReque
 	}
 
 	url := model.URL.Value
-	headers := model.RequestHeaders
+	method := model.Method.Value
+	requestHeaders := model.RequestHeaders
+	requestBody := strings.NewReader(model.RequestBody.Value)
+
+	if method == "" {
+		method = "GET"
+	}
 
 	client := &http.Client{}
 
-	request, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	request, err := http.NewRequestWithContext(ctx, method, url, requestBody)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating request",
@@ -117,7 +148,7 @@ func (d *httpDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourceReque
 		return
 	}
 
-	for name, value := range headers.Elems {
+	for name, value := range requestHeaders.Elems {
 		var header string
 		diags = tfsdk.ValueAs(ctx, value, &header)
 		resp.Diagnostics.Append(diags...)
@@ -212,7 +243,9 @@ func isContentTypeText(contentType string) bool {
 type modelV0 struct {
 	ID              types.String `tfsdk:"id"`
 	URL             types.String `tfsdk:"url"`
+	Method          types.String `tfsdk:"method"`
 	RequestHeaders  types.Map    `tfsdk:"request_headers"`
+	RequestBody     types.String `tfsdk:"request_body"`
 	ResponseHeaders types.Map    `tfsdk:"response_headers"`
 	ResponseBody    types.String `tfsdk:"response_body"`
 	Body            types.String `tfsdk:"body"`

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -335,11 +335,10 @@ func TestDataSource_UnsupportedMethod(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 							data "http" "http_test" {
- 								url = "%s/deleted"
+ 								url = "%s/200"
 								method = "OPTIONS" 
 							}`, testHttpMock.server.URL),
-				// Terraform < 0.15 wraps in a  different location to TF >= 0.15 hence the use of (?:\n| ).
-				ExpectError: regexp.MustCompile(`.*Value must be one of: \["\\"GET\\"" "\\"POST\\"" "\\"HEAD\\""),
+				ExpectError: regexp.MustCompile(`.*Value must be one of: \["\\"GET\\"" "\\"POST\\"" "\\"HEAD\\""`),
 			},
 		},
 	})

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -252,7 +252,6 @@ func TestDataSource_Provisioner(t *testing.T) {
 							data "http" "http_test" {
 								url = "%s"
 							}
-
 							resource "null_resource" "example" {
   								provisioner "local-exec" {
     								command = contains([201, 204], data.http.http_test.status_code)
@@ -265,13 +264,151 @@ func TestDataSource_Provisioner(t *testing.T) {
 							data "http" "http_test" {
 								url = "%s"
 							}
-
 							resource "null_resource" "example" {
   								provisioner "local-exec" {
     								command = contains([200], data.http.http_test.status_code)
   								}
 							}`, svr.URL),
 				Check: resource.TestCheckResourceAttr("data.http.http_test", "status_code", "200"),
+			},
+		},
+	})
+}
+
+func TestDataSource_POST_201(t *testing.T) {
+	testHttpMock := setUpMockHttpServer()
+
+	defer testHttpMock.server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+ 								url = "%s/create"
+								method = "POST" 
+							}`, testHttpMock.server.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "created"),
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "201"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_PUT_201(t *testing.T) {
+	testHttpMock := setUpMockHttpServer()
+
+	defer testHttpMock.server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+ 								url = "%s/recreate"
+								method = "PUT" 
+							}`, testHttpMock.server.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "recreated"),
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "201"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_PATCH_200(t *testing.T) {
+	testHttpMock := setUpMockHttpServer()
+
+	defer testHttpMock.server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+ 								url = "%s/modified"
+								method = "PATCH" 
+							}`, testHttpMock.server.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "modified"),
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_DELETE_204(t *testing.T) {
+	testHttpMock := setUpMockHttpServer()
+
+	defer testHttpMock.server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+ 								url = "%s/deleted"
+								method = "DELETE" 
+							}`, testHttpMock.server.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", ""),
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "204"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_HEAD_204(t *testing.T) {
+	testHttpMock := setUpMockHttpServer()
+
+	defer testHttpMock.server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+ 								url = "%s/head"
+								method = "HEAD" 
+							}`, testHttpMock.server.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "response_headers.Content-Type", "text/plain"),
+					resource.TestCheckResourceAttr("data.http.http_test", "response_headers.X-Single", "foobar"),
+					resource.TestCheckResourceAttr("data.http.http_test", "response_headers.X-Double", "1, 2"),
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", ""),
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_UnsupportedMethod(t *testing.T) {
+	testHttpMock := setUpMockHttpServer()
+
+	defer testHttpMock.server.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+ 								url = "%s/deleted"
+								method = "OPTIONS" 
+							}`, testHttpMock.server.URL),
+				// Terraform < 0.15 wraps in a  different location to TF >= 0.15 hence the use of (?:\n| ).
+				ExpectError: regexp.MustCompile(`.*Value must be one of: \["\\"GET\\"" "\\"POST\\"" "\\"PUT\\"" "\\"PATCH\\""(?:\n| )"\\"DELETE\\""(?:\n| )"\\"HEAD\\""`),
 			},
 		},
 	})
@@ -312,6 +449,29 @@ func setUpMockHttpServer() *TestHttpMock {
 				w.Header().Set("Content-Type", "application/x-x509-ca-cert")
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte("pem"))
+			case "/create":
+				if r.Method == "POST" {
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write([]byte("created"))
+				}
+			case "/recreate":
+				if r.Method == "PUT" {
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write([]byte("recreated"))
+				}
+			case "/modified":
+				if r.Method == "PATCH" {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte("modified"))
+				}
+			case "/deleted":
+				if r.Method == "DELETE" {
+					w.WriteHeader(http.StatusNoContent)
+				}
+			case "/head":
+				if r.Method == "HEAD" {
+					w.WriteHeader(http.StatusOK)
+				}
 			default:
 				w.WriteHeader(http.StatusNotFound)
 			}

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -298,75 +298,6 @@ func TestDataSource_POST_201(t *testing.T) {
 	})
 }
 
-func TestDataSource_PUT_201(t *testing.T) {
-	testHttpMock := setUpMockHttpServer()
-
-	defer testHttpMock.server.Close()
-
-	resource.UnitTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: protoV5ProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-							data "http" "http_test" {
- 								url = "%s/recreate"
-								method = "PUT" 
-							}`, testHttpMock.server.URL),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "recreated"),
-					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "201"),
-				),
-			},
-		},
-	})
-}
-
-func TestDataSource_PATCH_200(t *testing.T) {
-	testHttpMock := setUpMockHttpServer()
-
-	defer testHttpMock.server.Close()
-
-	resource.UnitTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: protoV5ProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-							data "http" "http_test" {
- 								url = "%s/modified"
-								method = "PATCH" 
-							}`, testHttpMock.server.URL),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "modified"),
-					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "200"),
-				),
-			},
-		},
-	})
-}
-
-func TestDataSource_DELETE_204(t *testing.T) {
-	testHttpMock := setUpMockHttpServer()
-
-	defer testHttpMock.server.Close()
-
-	resource.UnitTest(t, resource.TestCase{
-		ProtoV5ProviderFactories: protoV5ProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-							data "http" "http_test" {
- 								url = "%s/deleted"
-								method = "DELETE" 
-							}`, testHttpMock.server.URL),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.http.http_test", "response_body", ""),
-					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "204"),
-				),
-			},
-		},
-	})
-}
-
 func TestDataSource_HEAD_204(t *testing.T) {
 	testHttpMock := setUpMockHttpServer()
 
@@ -408,7 +339,7 @@ func TestDataSource_UnsupportedMethod(t *testing.T) {
 								method = "OPTIONS" 
 							}`, testHttpMock.server.URL),
 				// Terraform < 0.15 wraps in a  different location to TF >= 0.15 hence the use of (?:\n| ).
-				ExpectError: regexp.MustCompile(`.*Value must be one of: \["\\"GET\\"" "\\"POST\\"" "\\"PUT\\"" "\\"PATCH\\""(?:\n| )"\\"DELETE\\""(?:\n| )"\\"HEAD\\""`),
+				ExpectError: regexp.MustCompile(`.*Value must be one of: \["\\"GET\\"" "\\"POST\\"" "\\"HEAD\\""),
 			},
 		},
 	})
@@ -453,20 +384,6 @@ func setUpMockHttpServer() *TestHttpMock {
 				if r.Method == "POST" {
 					w.WriteHeader(http.StatusCreated)
 					_, _ = w.Write([]byte("created"))
-				}
-			case "/recreate":
-				if r.Method == "PUT" {
-					w.WriteHeader(http.StatusCreated)
-					_, _ = w.Write([]byte("recreated"))
-				}
-			case "/modified":
-				if r.Method == "PATCH" {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write([]byte("modified"))
-				}
-			case "/deleted":
-				if r.Method == "DELETE" {
-					w.WriteHeader(http.StatusNoContent)
 				}
 			case "/head":
 				if r.Method == "HEAD" {


### PR DESCRIPTION
References: #21 

`terraform-provider-http` uses a hardcoded HTTP **GET** request method.

The changes contained within this PR allow for optionally specifying:
- request method, one of GET, POST, PUT, PATCH, DELETE
- request body  

These changes are outlined in the [HTTP Verbs](https://docs.google.com/document/d/1mdvfNiNKarz_ipuqffqbQrDsQLmW-GhgXPaFo-NgGFc/edit#heading=h.buibml32t1vx) of the [HTTP Utility Provider Enhancements](https://docs.google.com/document/d/1mdvfNiNKarz_ipuqffqbQrDsQLmW-GhgXPaFo-NgGFc/edit#) RFC.

Closes: #85 
Closes: #52 
Closes: #21 