### PR TITLE
Allow application/x-pem-file content type

### DIFF
--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -152,6 +152,7 @@ func isContentTypeText(contentType string) bool {
 		regexp.MustCompile("^text/.+"),
 		regexp.MustCompile("^application/json$"),
 		regexp.MustCompile(`^application/samlmetadata\+xml`),
+		regexp.MustCompile(`^application/x-pem-file$`),
 	}
 
 	for _, r := range allowedContentTypes {


### PR DESCRIPTION
This refers to PEM encoded files often used for certificates and related
data.

Example source for this content type: https://github.com/ietf-wg-acme/acme/issues/120