### PR TITLE
Reinstate `body` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.1 (unreleased)
+
+BUG FIXES
+
+* data-source/http: Reinstated previously deprecated and removed `body` attribute ([#166](https://github.com/hashicorp/terraform-provider-http/pull/166)).
+
+
 ## 3.0.0 (July 27, 2022)
 
 NOTES:

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -131,6 +131,7 @@ resource "null_resource" "example" {
 
 ### Read-Only
 
+- `body` (String, Deprecated) The response body returned as a string. **NOTE**: This is deprecated, use `response_body` instead.
 - `id` (String) The ID of this resource.
 - `response_body` (String) The response body returned as a string.
 - `response_headers` (Map of String) A map of response header field names and values. Duplicate headers are concatenated according to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -55,6 +55,14 @@ your control should be treated as untrustworthy.`,
 				Computed:    true,
 			},
 
+			"body": {
+				Description: "The response body returned as a string. " +
+					"**NOTE**: This is deprecated, use `response_body` instead.",
+				Type:               types.StringType,
+				Computed:           true,
+				DeprecationMessage: "Use response_body instead",
+			},
+
 			"response_headers": {
 				Description: `A map of response header field names and values.` +
 					` Duplicate headers are concatenated according to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).`,
@@ -168,6 +176,7 @@ func (d *httpDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourceReque
 	model.ID = types.String{Value: url}
 	model.ResponseHeaders = respHeadersState
 	model.ResponseBody = types.String{Value: responseBody}
+	model.Body = types.String{Value: responseBody}
 	model.StatusCode = types.Int64{Value: int64(response.StatusCode)}
 
 	diags = resp.State.Set(ctx, model)
@@ -206,5 +215,6 @@ type modelV0 struct {
 	RequestHeaders  types.Map    `tfsdk:"request_headers"`
 	ResponseHeaders types.Map    `tfsdk:"response_headers"`
 	ResponseBody    types.String `tfsdk:"response_body"`
+	Body            types.String `tfsdk:"body"`
 	StatusCode      types.Int64  `tfsdk:"status_code"`
 }

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -213,6 +213,7 @@ func TestDataSource_UpgradeFromVersion2_2_0(t *testing.T) {
 							}`, testHttpMock.server.URL),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "1.0.0"),
+					resource.TestCheckResourceAttr("data.http.http_test", "body", "1.0.0"),
 					resource.TestCheckResourceAttr("data.http.http_test", "response_headers.Content-Type", "text/plain"),
 					resource.TestCheckResourceAttr("data.http.http_test", "response_headers.X-Single", "foobar"),
 					resource.TestCheckResourceAttr("data.http.http_test", "response_headers.X-Double", "1, 2"),


### PR DESCRIPTION
This PR reinstates the deprecated `body` attribute that was removed as part of `v3.0.0` changes.