### PR TITLE
Bendbennett/issues 157

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.0 (unreleased)
+
+ENHANCEMENTS:
+
+* data-source/http: `response_body_base64_std` has been added and contains a standard base64 encoding of the response body ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
+* data-source/http: Replaced issuing warning on the basis of possible non-text `Content-Type` with issuing warning if response body does not contain valid UTF-8. ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
+
 ## 3.1.0 (August 30, 2022)
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENTS:
 
-* data-source/http: `response_body_base64_std` has been added and contains a standard base64 encoding of the response body ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
+* data-source/http: `response_body_base64` has been added and contains a standard base64 encoding of the response body ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
 * data-source/http: Replaced issuing warning on the basis of possible non-text `Content-Type` with issuing warning if response body does not contain valid UTF-8. ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
 
 ## 3.1.0 (August 30, 2022)

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -152,5 +152,6 @@ resource "null_resource" "example" {
 - `body` (String, Deprecated) The response body returned as a string. **NOTE**: This is deprecated, use `response_body` instead.
 - `id` (String) The URL used for the request.
 - `response_body` (String) The response body returned as a string.
+- `response_body_base64_std` (String) The response body encoded as base64 (standard) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-4).
 - `response_headers` (Map of String) A map of response header field names and values. Duplicate headers are concatenated according to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).
 - `status_code` (Number) The HTTP response status code.

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -152,6 +152,6 @@ resource "null_resource" "example" {
 - `body` (String, Deprecated) The response body returned as a string. **NOTE**: This is deprecated, use `response_body` instead.
 - `id` (String) The URL used for the request.
 - `response_body` (String) The response body returned as a string.
-- `response_body_base64_std` (String) The response body encoded as base64 (standard) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-4).
+- `response_body_base64` (String) The response body encoded as base64 (standard) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-4).
 - `response_headers` (Map of String) A map of response header field names and values. Duplicate headers are concatenated according to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).
 - `status_code` (Number) The HTTP response status code.

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -96,7 +96,7 @@ your control should be treated as untrustworthy.`,
 				Computed:    true,
 			},
 
-			"response_body_base64_std": {
+			"response_body_base64": {
 				Description: "The response body encoded as base64 (standard) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-4).",
 				Type:        types.StringType,
 				Computed:    true,
@@ -195,7 +195,7 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	responseBody := string(bytes)
-	responseBodyBase64Std := base64.StdEncoding.EncodeToString(bytes)
+	responseBodyBase64 := base64.StdEncoding.EncodeToString(bytes)
 
 	responseHeaders := make(map[string]string)
 	for k, v := range response.Header {
@@ -215,7 +215,7 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	model.ID = types.String{Value: url}
 	model.ResponseHeaders = respHeadersState
 	model.ResponseBody = types.String{Value: responseBody}
-	model.ResponseBodyBase64Std = types.String{Value: responseBodyBase64Std}
+	model.ResponseBodyBase64 = types.String{Value: responseBodyBase64}
 	model.Body = types.String{Value: responseBody}
 	model.StatusCode = types.Int64{Value: int64(response.StatusCode)}
 
@@ -224,14 +224,14 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 }
 
 type modelV0 struct {
-	ID                    types.String `tfsdk:"id"`
-	URL                   types.String `tfsdk:"url"`
-	Method                types.String `tfsdk:"method"`
-	RequestHeaders        types.Map    `tfsdk:"request_headers"`
-	RequestBody           types.String `tfsdk:"request_body"`
-	ResponseHeaders       types.Map    `tfsdk:"response_headers"`
-	ResponseBody          types.String `tfsdk:"response_body"`
-	ResponseBodyBase64Std types.String `tfsdk:"response_body_base64_std"`
-	Body                  types.String `tfsdk:"body"`
-	StatusCode            types.Int64  `tfsdk:"status_code"`
+	ID                 types.String `tfsdk:"id"`
+	URL                types.String `tfsdk:"url"`
+	Method             types.String `tfsdk:"method"`
+	RequestHeaders     types.Map    `tfsdk:"request_headers"`
+	RequestBody        types.String `tfsdk:"request_body"`
+	ResponseHeaders    types.Map    `tfsdk:"response_headers"`
+	ResponseBody       types.String `tfsdk:"response_body"`
+	ResponseBodyBase64 types.String `tfsdk:"response_body_base64"`
+	Body               types.String `tfsdk:"body"`
+	StatusCode         types.Int64  `tfsdk:"status_code"`
 }

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"mime"
 	"net/http"
-	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -96,6 +96,12 @@ your control should be treated as untrustworthy.`,
 				Computed:    true,
 			},
 
+			"response_body_base64_std": {
+				Description: "The response body encoded as base64 (standard) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-4).",
+				Type:        types.StringType,
+				Computed:    true,
+			},
+
 			"body": {
 				Description: "The response body returned as a string. " +
 					"**NOTE**: This is deprecated, use `response_body` instead.",
@@ -172,14 +178,6 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	defer response.Body.Close()
 
-	contentType := response.Header.Get("Content-Type")
-	if !isContentTypeText(contentType) {
-		resp.Diagnostics.AddWarning(
-			fmt.Sprintf("Content-Type is not recognized as a text type, got %q", contentType),
-			"If the content is binary data, Terraform may not properly handle the contents of the response.",
-		)
-	}
-
 	bytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -189,7 +187,15 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
+	if !utf8.Valid(bytes) {
+		resp.Diagnostics.AddWarning(
+			"Response body is not recognized as UTF-8",
+			"Terraform may not properly handle the response_body if the contents are binary.",
+		)
+	}
+
 	responseBody := string(bytes)
+	responseBodyBase64Std := base64.StdEncoding.EncodeToString(bytes)
 
 	responseHeaders := make(map[string]string)
 	for k, v := range response.Header {
@@ -209,6 +215,7 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	model.ID = types.String{Value: url}
 	model.ResponseHeaders = respHeadersState
 	model.ResponseBody = types.String{Value: responseBody}
+	model.ResponseBodyBase64Std = types.String{Value: responseBodyBase64Std}
 	model.Body = types.String{Value: responseBody}
 	model.StatusCode = types.Int64{Value: int64(response.StatusCode)}
 
@@ -216,40 +223,15 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	resp.Diagnostics.Append(diags...)
 }
 
-// This is to prevent potential issues w/ binary files
-// and generally unprintable characters
-// See https://github.com/hashicorp/terraform/pull/3858#issuecomment-156856738
-func isContentTypeText(contentType string) bool {
-
-	parsedType, params, err := mime.ParseMediaType(contentType)
-	if err != nil {
-		return false
-	}
-
-	allowedContentTypes := []*regexp.Regexp{
-		regexp.MustCompile("^text/.+"),
-		regexp.MustCompile("^application/json$"),
-		regexp.MustCompile(`^application/samlmetadata\+xml`),
-	}
-
-	for _, r := range allowedContentTypes {
-		if r.MatchString(parsedType) {
-			charset := strings.ToLower(params["charset"])
-			return charset == "" || charset == "utf-8" || charset == "us-ascii"
-		}
-	}
-
-	return false
-}
-
 type modelV0 struct {
-	ID              types.String `tfsdk:"id"`
-	URL             types.String `tfsdk:"url"`
-	Method          types.String `tfsdk:"method"`
-	RequestHeaders  types.Map    `tfsdk:"request_headers"`
-	RequestBody     types.String `tfsdk:"request_body"`
-	ResponseHeaders types.Map    `tfsdk:"response_headers"`
-	ResponseBody    types.String `tfsdk:"response_body"`
-	Body            types.String `tfsdk:"body"`
-	StatusCode      types.Int64  `tfsdk:"status_code"`
+	ID                    types.String `tfsdk:"id"`
+	URL                   types.String `tfsdk:"url"`
+	Method                types.String `tfsdk:"method"`
+	RequestHeaders        types.Map    `tfsdk:"request_headers"`
+	RequestBody           types.String `tfsdk:"request_body"`
+	ResponseHeaders       types.Map    `tfsdk:"response_headers"`
+	ResponseBody          types.String `tfsdk:"response_body"`
+	ResponseBodyBase64Std types.String `tfsdk:"response_body_base64_std"`
+	Body                  types.String `tfsdk:"body"`
+	StatusCode            types.Int64  `tfsdk:"status_code"`
 }

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"testing"
-	"unicode/utf8"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -379,7 +378,7 @@ func TestDataSource_ResponseBodyBinary(t *testing.T) {
 
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/gif")
-		_, _ = fmt.Fprintf(w, transPixel)
+		_, _ = w.Write([]byte(transPixel))
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer svr.Close()
@@ -400,8 +399,6 @@ func TestDataSource_ResponseBodyBinary(t *testing.T) {
 			},
 		},
 	})
-
-	fmt.Println(utf8.Valid([]byte(`你好世界`)))
 }
 
 type TestHttpMock struct {

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -342,6 +343,65 @@ func TestDataSource_UnsupportedMethod(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestDataSource_ResponseBodyText(t *testing.T) {
+	t.Parallel()
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`你好世界`)) // Hello world
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url = "%s"
+							}`, svr.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "你好世界"),
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body_base64_std", "5L2g5aW95LiW55WM"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_ResponseBodyBinary(t *testing.T) {
+	t.Parallel()
+
+	// 1 x 1 transparent gif pixel.
+	const transPixel = "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B"
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/gif")
+		_, _ = fmt.Fprintf(w, transPixel)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url = "%s"
+							}`, svr.URL),
+				Check: resource.ComposeTestCheckFunc(
+					// Note the replacement character in the string representation in `response_body`.
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "GIF89a\x01\x00\x01\x00�\x00\x00\x00\x00\x00\x00\x00\x00!�\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"),
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body_base64_std", "R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="),
+				),
+			},
+		},
+	})
+
+	fmt.Println(utf8.Valid([]byte(`你好世界`)))
 }
 
 type TestHttpMock struct {

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -363,7 +363,7 @@ func TestDataSource_ResponseBodyText(t *testing.T) {
 							}`, svr.URL),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "你好世界"),
-					resource.TestCheckResourceAttr("data.http.http_test", "response_body_base64_std", "5L2g5aW95LiW55WM"),
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body_base64", "5L2g5aW95LiW55WM"),
 				),
 			},
 		},
@@ -394,7 +394,7 @@ func TestDataSource_ResponseBodyBinary(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// Note the replacement character in the string representation in `response_body`.
 					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "GIF89a\x01\x00\x01\x00�\x00\x00\x00\x00\x00\x00\x00\x00!�\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"),
-					resource.TestCheckResourceAttr("data.http.http_test", "response_body_base64_std", "R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="),
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body_base64", "R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="),
 				),
 			},
 		},


### PR DESCRIPTION
It looks like the [PR:158](https://github.com/hashicorp/terraform-provider-http/pull/158) is in stale state, so I decided to rebase it on top of the fresh `main` and remove `_std` suffix with respect to other large Terraform providers.
Correct me if I did something wrong, bet we need this feature.