### PR TITLE
Base64 encode response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.3.0 (unreleased)
+
+ENHANCEMENTS:
+
+* data-source/http: `response_body_base64_std` has been added and contains a standard base64 encoding of the response body ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
+* data-source/http: Replaced issuing warning on the basis of possible non-text `Content-Type` with issuing warning if response body does not contain valid UTF-8. ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
+
 ## 3.2.1 (November 7, 2022)
 
 BUG FIXES
@@ -10,6 +17,7 @@ ENHANCEMENTS:
 
 * data-source/http: Added `ca_cert_pem` attribute which allows PEM encoded certificate(s) to be included in the set of root certificate authorities used when verifying server certificates ([#125](https://github.com/hashicorp/terraform-provider-http/pull/125)).
 * data-source/http: Added `insecure` attribute to allow disabling the verification of a server's certificate chain and host name. Defaults to `false` ([#125](https://github.com/hashicorp/terraform-provider-http/pull/125)).
+=======
 
 ## 3.1.0 (August 30, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ ENHANCEMENTS:
 
 * data-source/http: Added `ca_cert_pem` attribute which allows PEM encoded certificate(s) to be included in the set of root certificate authorities used when verifying server certificates ([#125](https://github.com/hashicorp/terraform-provider-http/pull/125)).
 * data-source/http: Added `insecure` attribute to allow disabling the verification of a server's certificate chain and host name. Defaults to `false` ([#125](https://github.com/hashicorp/terraform-provider-http/pull/125)).
-=======
 
 ## 3.1.0 (August 30, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ENHANCEMENTS:
 
-* data-source/http: `response_body_base64_std` has been added and contains a standard base64 encoding of the response body ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
+* data-source/http: `response_body_base64` has been added and contains a standard base64 encoding of the response body ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
 * data-source/http: Replaced issuing warning on the basis of possible non-text `Content-Type` with issuing warning if response body does not contain valid UTF-8. ([#158](https://github.com/hashicorp/terraform-provider-http/pull/158)).
 
 ## 3.2.1 (November 7, 2022)

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -154,5 +154,6 @@ resource "null_resource" "example" {
 - `body` (String, Deprecated) The response body returned as a string. **NOTE**: This is deprecated, use `response_body` instead.
 - `id` (String) The URL used for the request.
 - `response_body` (String) The response body returned as a string.
+- `response_body_base64_std` (String) The response body encoded as base64 (standard) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-4).
 - `response_headers` (Map of String) A map of response header field names and values. Duplicate headers are concatenated according to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).
 - `status_code` (Number) The HTTP response status code.

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -154,6 +154,6 @@ resource "null_resource" "example" {
 - `body` (String, Deprecated) The response body returned as a string. **NOTE**: This is deprecated, use `response_body` instead.
 - `id` (String) The URL used for the request.
 - `response_body` (String) The response body returned as a string.
-- `response_body_base64_std` (String) The response body encoded as base64 (standard) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-4).
+- `response_body_base64` (String) The response body encoded as base64 (standard) as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-4).
 - `response_headers` (Map of String) A map of response header field names and values. Duplicate headers are concatenated according to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).
 - `status_code` (Number) The HTTP response status code.

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -246,10 +246,10 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		// TODO(ddelnano): Determine the appropriate fix for this
 		// This causes acceptance tests to fail on all terraform v0.14 releases and is
 		// fixed in v0.15.0-alpha20210107.
-		resp.Diagnostics.AddWarning(
-			"Response body is not recognized as UTF-8",
-			"Terraform may not properly handle the response_body if the contents are binary.",
-		)
+		// resp.Diagnostics.AddWarning(
+		// 	"Response body is not recognized as UTF-8",
+		// 	"Terraform may not properly handle the response_body if the contents are binary.",
+		// )
 	}
 
 	responseBody := string(bytes)

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -243,13 +243,10 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	if !utf8.Valid(bytes) {
-		// TODO(ddelnano): Determine the appropriate fix for this
-		// This causes acceptance tests to fail on all terraform v0.14 releases and is
-		// fixed in v0.15.0-alpha20210107.
-		// resp.Diagnostics.AddWarning(
-		// 	"Response body is not recognized as UTF-8",
-		// 	"Terraform may not properly handle the response_body if the contents are binary.",
-		// )
+		resp.Diagnostics.AddWarning(
+			"Response body is not recognized as UTF-8",
+			"Terraform may not properly handle the response_body if the contents are binary.",
+		)
 	}
 
 	responseBody := string(bytes)


### PR DESCRIPTION
This includes the changes in #158 with a temporary fix to address the CI failures. I was able to track this down to all versions of the v0.14.x releases and its related to the warning diag added.

While my testing proves that the failures on #158 are related to the diag, upon rebasing my branch I'm no longer able to reproduce the test failure. So it seems there is some interaction between the terraform version, terraform-plugin-sdk or terraform-plugin-framework version that causes the v0.14.x diag issues.
 
## Testing
- [x] `make testacc` passes when terraform v0.14.x is installed in my PATH (fails without the commented out diag)
```
ddelnano@ddelnano-desktop:~/code/terraform-provider-http$ make testacc
TF_ACC=1 go test -v -cover -timeout 120m ./...
?       github.com/terraform-providers/terraform-provider-http  [no test files]
=== RUN   TestDataSource_200
--- PASS: TestDataSource_200 (1.00s)
=== RUN   TestDataSource_404
--- PASS: TestDataSource_404 (0.98s)
=== RUN   TestDataSource_withAuthorizationRequestHeader_200
--- PASS: TestDataSource_withAuthorizationRequestHeader_200 (0.99s)
=== RUN   TestDataSource_withAuthorizationRequestHeader_403
--- PASS: TestDataSource_withAuthorizationRequestHeader_403 (0.98s)
=== RUN   TestDataSource_utf8_200
--- PASS: TestDataSource_utf8_200 (0.98s)
=== RUN   TestDataSource_utf16_200
--- PASS: TestDataSource_utf16_200 (0.99s)
=== RUN   TestDataSource_UpgradeFromVersion2_2_0
--- PASS: TestDataSource_UpgradeFromVersion2_2_0 (5.58s)
=== RUN   TestDataSource_Provisioner
=== PAUSE TestDataSource_Provisioner
=== RUN   TestDataSource_POST_201
--- PASS: TestDataSource_POST_201 (1.00s)
=== RUN   TestDataSource_HEAD_204
--- PASS: TestDataSource_HEAD_204 (1.01s)
=== RUN   TestDataSource_UnsupportedMethod
--- PASS: TestDataSource_UnsupportedMethod (0.25s)
=== RUN   TestDataSource_ResponseBodyText
=== PAUSE TestDataSource_ResponseBodyText
=== RUN   TestDataSource_ResponseBodyBinary
=== PAUSE TestDataSource_ResponseBodyBinary
=== CONT  TestDataSource_Provisioner
=== CONT  TestDataSource_ResponseBodyBinary
=== CONT  TestDataSource_ResponseBodyText
--- PASS: TestDataSource_ResponseBodyBinary (1.49s)
--- PASS: TestDataSource_ResponseBodyText (1.51s)
--- PASS: TestDataSource_Provisioner (6.60s)
PASS
coverage: 84.5% of statements
ok      github.com/terraform-providers/terraform-provider-http/internal/provider        20.375s coverage: 84.5% of statements
?       github.com/terraform-providers/terraform-provider-http/terraform        [no test files]
```
- [x] `make testacc` fails when it's uncommented with terraform v0.14.x
```
ddelnano@ddelnano-desktop:~/code/terraform-provider-http$ terraform --version
Terraform v0.14.9

Your version of Terraform is out of date! The latest version
is 1.3.6. You can update by downloading from https://www.terraform.io/downloads.html

# Use original branch that was failing
ddelnano@ddelnano-desktop:~/code/terraform-provider-http$ git checkout bendbennett/issues-157
Switched to branch 'bendbennett/issues-157'
Your branch is up to date with 'origin/bendbennett/issues-157'.
ddelnano@ddelnano-desktop:~/code/terraform-provider-http$ make testacc
TF_ACC=1 go test -v -cover -timeout 120m ./...
?       github.com/terraform-providers/terraform-provider-http  [no test files]
=== RUN   TestDataSource_200
--- PASS: TestDataSource_200 (0.98s)
=== RUN   TestDataSource_404
--- PASS: TestDataSource_404 (1.01s)
=== RUN   TestDataSource_withAuthorizationRequestHeader_200
--- PASS: TestDataSource_withAuthorizationRequestHeader_200 (0.99s)
=== RUN   TestDataSource_withAuthorizationRequestHeader_403
--- PASS: TestDataSource_withAuthorizationRequestHeader_403 (1.00s)
=== RUN   TestDataSource_utf8_200
--- PASS: TestDataSource_utf8_200 (0.99s)
=== RUN   TestDataSource_utf16_200
--- PASS: TestDataSource_utf16_200 (0.99s)
=== RUN   TestDataSource_UpgradeFromVersion2_2_0
--- PASS: TestDataSource_UpgradeFromVersion2_2_0 (5.59s)
=== RUN   TestDataSource_Provisioner
=== PAUSE TestDataSource_Provisioner
=== RUN   TestDataSource_POST_201
--- PASS: TestDataSource_POST_201 (0.98s)
=== RUN   TestDataSource_HEAD_204
--- PASS: TestDataSource_HEAD_204 (1.06s)
=== RUN   TestDataSource_UnsupportedMethod
--- PASS: TestDataSource_UnsupportedMethod (0.25s)
=== RUN   TestDataSource_ResponseBodyText
=== PAUSE TestDataSource_ResponseBodyText
=== RUN   TestDataSource_ResponseBodyBinary
=== PAUSE TestDataSource_ResponseBodyBinary
=== CONT  TestDataSource_Provisioner
=== CONT  TestDataSource_ResponseBodyBinary
=== CONT  TestDataSource_ResponseBodyText
=== CONT  TestDataSource_ResponseBodyBinary
    data_source_http_test.go:386: Step 1/1 error: Check failed: Check 1/2 error: Not found: data.http.http_test in [root]
--- FAIL: TestDataSource_ResponseBodyBinary (0.90s)
--- PASS: TestDataSource_ResponseBodyText (1.46s)
--- PASS: TestDataSource_Provisioner (6.59s)
FAIL
coverage: 84.7% of statements
FAIL    github.com/terraform-providers/terraform-provider-http/internal/provider        20.428s
?       github.com/terraform-providers/terraform-provider-http/terraform        [no test files]
FAIL
make: *** [GNUmakefile:23: testacc] Error 1

```

@bendbennett would appreciate if we could get this merged since as I mentioned this would allow me to piggyback off an official provider's functionality rather than building this into the provider I maintain. 