### PR TITLE
ci: merging `golangci-lint` rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,25 @@
-linters:
-  # Default linters enabled
-  # See: https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+issues:
+  max-per-linter: 0
+  max-same-issues: 0
 
-  # Additional linters enabled
+linters:
+  disable-all: true
   enable:
     - durationcheck
+    - errcheck
     - exportloopref
+    - forcetypeassert
     - godot
     - gofmt
+    - gosimple
+    - ineffassign
     - makezero
     - misspell
     - nilerr
     - predeclared
+    - staticcheck
     - tenv
     - unconvert
     - unparam
-
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
+    - unused
+    - vet

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 	"net/url"
@@ -238,7 +238,7 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		)
 	}
 
-	bytes, err := ioutil.ReadAll(response.Body)
+	bytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading response body",


### PR DESCRIPTION
contributes to:
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/102

### Notes
- Fixed `ioutil` deprecation
- Skipping `paralleltest` for the providers
