### PR TITLE
Addressing #241 and #192 - Allow 'PUT' requests

### DIFF
--- a/examples/data-sources/http/data-source.tf
+++ b/examples/data-sources/http/data-source.tf
@@ -24,3 +24,13 @@ data "http" "example_post" {
   # Optional request body
   request_body = "request body"
 }
+
+# The following example shows how to issue an HTTP PUT request
+# supplying an optional request body.
+data "http" "example_put" {
+  url    = "https://checkpoint-api.hashicorp.com/v1/check/terraform"
+  method = "PUT"
+
+  # Optional request body
+  request_body = "request body"
+}

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -90,6 +90,7 @@ a 5xx-range (except 501) status code is received. For further details see
 						http.MethodGet,
 						http.MethodPost,
 						http.MethodHead,
+						http.MethodPut,
 					}...),
 				},
 			},


### PR DESCRIPTION
I think PUT falls in the spirit of idempotent design guidance and shouldn't negatively impact stability.

Some resources for consideration:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT (specific call out to being idempotent)
- https://stackoverflow.com/questions/630453/what-is-the-difference-between-post-and-put-in-http - create or replace is an idempotent operation (or should be ;) )
- https://www.rfc-editor.org/rfc/rfc2616#section-9.6 

A PUT operation is a critical operation for applying updates to resources. 