### PR TITLE
data-source/http: Ensure HTTP request body is not sent unless configured

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240229-151134.yaml
+++ b/.changes/unreleased/BUG FIXES-20240229-151134.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'data-source/http: Ensured HTTP request body is not sent unless configured'
+time: 2024-02-29T15:11:34.198556-05:00
+custom:
+  Issue: "388"

--- a/.changes/unreleased/NOTES-20240229-151426.yaml
+++ b/.changes/unreleased/NOTES-20240229-151426.yaml
@@ -1,0 +1,9 @@
+kind: NOTES
+body: 'data-source/http: Previously the HTTP request would unexpectedly always contain
+  a body for all requests. Certain HTTP server implementations are sensitive to this
+  data existing if it is not expected. Requests now only contain a request body if
+  the `request_body` attribute is explicitly set. To exactly preserve the previous
+  behavior, set `request_body = ""`.'
+time: 2024-02-29T15:14:26.883908-05:00
+custom:
+  Issue: "388"


### PR DESCRIPTION
Closes #388

Previously the HTTP request would unexpectedly always contain a body for all requests. Certain HTTP server implementations are sensitive to this data existing if it is not expected. Requests now only contain a request body if the `request_body` attribute is explicitly set. To exactly preserve the previous behavior, set `request_body = ""`.

Added new acceptance testing for `request_body` handling. Go net/http server implementations seem to ignore this problematic situation (or it was not easy to determine), so also verified with a real world configuration using a temporary acceptance test as well as manually running Terraform using a development build containing these changes:

```
// Reference: https://github.com/hashicorp/terraform-provider-http/issues/388
func TestDataSource_RequestBody_Null(t *testing.T) {
	t.Parallel()

	resource.Test(t, resource.TestCase{
		ProtoV5ProviderFactories: protoV5ProviderFactories(),
		Steps: []resource.TestStep{
			{
				Config: `
					data "http" "test" {
						url = "https://www.cloudflare.com/ips-v4"
					}`,
				Check: resource.ComposeAggregateTestCheckFunc(
					resource.TestCheckResourceAttr("data.http.test", "status_code", "200"),
				),
			},
		},
	})
}
```

This real world acceptance test is not added as the server may change its implementation in the future.