### PR TITLE
Clarify HTTP `Host` header changelog wording and make header check case-insensitive

### DIFF
--- a/.changes/unreleased/NOTES-20240723-162543.yaml
+++ b/.changes/unreleased/NOTES-20240723-162543.yaml
@@ -1,6 +1,6 @@
 kind: NOTES
 body: |+
-  data-source/http: Previous versions of this provider ignored any `Host` headers specified in the `request_headers` attribute when setting the HTTP request. Any specified `Host` request headers will now override the `url` attribute host.
+  data-source/http: Previous versions of this provider ignored any `Host` headers specified in the `request_headers` attribute when setting the HTTP request. Any specified `Host` request header will now be set on the HTTP request.
   
   For example, in the following configuration:
   ```hcl
@@ -11,7 +11,7 @@ body: |+
     }
   }
   ```
-  The HTTP request host will now be `www.differentexample.com` instead of `www.example.com`.
+  The HTTP request URL host is still `www.example.com` but the HTTP request `Host` header will now be `www.differentexample.com` instead of `www.example.com`.
 time: 2024-07-23T16:25:43.160519-04:00
 custom:
   Issue: "440"

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -315,7 +315,7 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		}
 
 		request.Header.Set(name, header)
-		if name == "Host" {
+		if strings.ToLower(name) == "host" {
 			request.Host = header
 		}
 	}


### PR DESCRIPTION
Relates: #440 