### PR TITLE
all: Bump minimum Go module version to 1.22

### DIFF
--- a/.changes/unreleased/NOTES-20240910-073305.yaml
+++ b/.changes/unreleased/NOTES-20240910-073305.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'all: This release introduces no functional changes. It does however include
+  dependency updates which address upstream CVEs.'
+time: 2024-09-10T07:33:05.510635-04:00
+custom:
+  Issue: "452"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - godot
     - gofmt
     - gosimple
+    - govet
     - ineffassign
     - makezero
     - misspell
@@ -22,4 +23,3 @@ linters:
     - unconvert
     - unparam
     - unused
-    - vet

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -17,7 +17,7 @@ HTTP URLs and either [HTTP/1.1](https://datatracker.ietf.org/doc/html/rfc2616) o
 [SPDY](https://tools.ietf.org/id/draft-ietf-httpbis-http2-00.html), 
 [QUIC](https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-34)) are not supported.
 * Support usage of either `http` (plaintext) or `https` (secure) requests. The current version of this provider is 
-built with [Go 1.21](https://go.dev/doc/go1.21) which [supports](https://go.dev/doc/go1.18#tls10) 
+built with [Go 1.22](https://go.dev/doc/go1.22) which [supports](https://go.dev/doc/go1.18#tls10) 
 [TLS/1.0](https://www.ietf.org/rfc/rfc2246.txt) ([deprecated](https://datatracker.ietf.org/doc/rfc8996/)), 
 [TLS/1.1](https://datatracker.ietf.org/doc/html/rfc4346) ([deprecated](https://datatracker.ietf.org/doc/rfc8996/)), 
 [TLS/1.2](https://datatracker.ietf.org/doc/html/rfc5246) and 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ version it implements, and Terraform:
 ## Requirements
 
 * [Terraform](https://www.terraform.io/downloads)
-* [Go](https://go.dev/doc/install) (1.21)
+* [Go](https://go.dev/doc/install) (1.22)
 * [GNU Make](https://www.gnu.org/software/make/)
 * [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) (optional)
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/terraform-providers/terraform-provider-http
 
-go 1.21
-
-toolchain go1.21.6
+go 1.22.7
 
 require (
 	github.com/google/uuid v1.6.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.21
+go 1.22.7
 
 require (
 	github.com/hashicorp/copywrite v0.19.0


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-providers-devex-internal/issues/182

Bumps the minimum Go module to 1.22.7