### PR TITLE
feat: add `sensitive_request_headers` argument

### DIFF
--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -157,6 +157,7 @@ resource "null_resource" "example" {
 - `request_headers` (Map of String) A map of request header field names and values.
 - `request_timeout_ms` (Number) The request timeout in milliseconds.
 - `retry` (Block, Optional) Retry request configuration. By default there are no retries. Configuring this block will result in retries if an error is returned by the client (e.g., connection errors) or if a 5xx-range (except 501) status code is received. For further details see [go-retryablehttp](https://pkg.go.dev/github.com/hashicorp/go-retryablehttp). (see [below for nested schema](#nestedblock--retry))
+- `sensitive_request_headers` (Map of String, Sensitive) A map of request header field names and values regarded as sensitive. The header values are masked in CLI output, as well as Terraform state.
 
 ### Read-Only
 


### PR DESCRIPTION
This seeks to address issue #34 via `sensitive_request_headers`, which serves the same function as `request_headers`, but `sensitive_request_headers` are denoted as sensitive and their values are obscured as `*****` in Terraform state.