### PR TITLE
docs: Add documentation on non-2xx status code handling

### DIFF
--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -10,6 +10,8 @@ description: |-
   mechanism to authenticate the remote server except for general verification of
   the server certificate's chain of trust. Data retrieved from servers not under
   your control should be treated as untrustworthy.
+  The request will succeed even if the status code is not 2xx-range. You can
+  check for specific status codes in a postcondition.
   By default, there are no retries. Configuring the retry block will result in
   retries if an error is returned by the client (e.g., connection errors) or if
   a 5xx-range (except 501) status code is received. For further details see
@@ -28,6 +30,9 @@ will issue a warning if the result is not UTF-8 encoded.
 mechanism to authenticate the remote server except for general verification of
 the server certificate's chain of trust. Data retrieved from servers not under
 your control should be treated as untrustworthy.
+
+The request will succeed even if the status code is not 2xx-range. You can
+check for specific status codes in a postcondition.
 
 By default, there are no retries. Configuring the retry block will result in
 retries if an error is returned by the client (e.g., connection errors) or if 


### PR DESCRIPTION
## Description

The documentation is not explicit about whether non-2xx status codes cause the request to fail and whether the user should handle 4xx codes like 429. However, from https://github.com/hashicorp/terraform-provider-http/blob/main/CHANGELOG.md#300-july-27-2022 it is clear that the request succeeds in this case and the user should in fact use a postcondition if they require a success response.

## Rollback Plan

n/a - docs only change

## Changes to Security Controls

n/a - docs only change
