### PR TITLE
data-source/http: Add username and password attributes for HTTP Basic Auth (#51)

### DIFF
--- a/.changes/unreleased/issue-51.yaml
+++ b/.changes/unreleased/issue-51.yaml
@@ -1,0 +1,4 @@
+kind: ENHANCEMENTS
+body: 'data-source/http: Adds `username` and `password` attributes for HTTP Basic Authentication'
+custom:
+  Issue: 51

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -98,6 +98,23 @@ a 5xx-range (except 501) status code is received. For further details see
 				Optional:    true,
 			},
 
+			"username": schema.StringAttribute{
+				Description: "Username to use for HTTP Basic Authentication.",
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("password")),
+				},
+			},
+
+			"password": schema.StringAttribute{
+				Description: "Password to use for HTTP Basic Authentication.",
+				Optional:    true,
+				Sensitive:   true,
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("username")),
+				},
+			},
+
 			"request_body": schema.StringAttribute{
 				Description: "The request body as a string.",
 				Optional:    true,
@@ -350,6 +367,11 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		}
 	}
 
+	if !model.Username.IsNull() && !model.Password.IsNull() {
+		auth := base64.StdEncoding.EncodeToString([]byte(model.Username.ValueString() + ":" + model.Password.ValueString()))
+		request.Header.Set("Authorization", "Basic "+auth)
+	}
+
 	response, err := retryClient.Do(request)
 	if err != nil {
 		target := &url.Error{}
@@ -433,6 +455,8 @@ type modelV0 struct {
 	ClientCert         types.String `tfsdk:"client_cert_pem"`
 	ClientKey          types.String `tfsdk:"client_key_pem"`
 	Insecure           types.Bool   `tfsdk:"insecure"`
+	Username           types.String `tfsdk:"username"`
+	Password           types.String `tfsdk:"password"`
 	ResponseBody       types.String `tfsdk:"response_body"`
 	Body               types.String `tfsdk:"body"`
 	ResponseBodyBase64 types.String `tfsdk:"response_body_base64"`

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -695,6 +696,107 @@ func TestDataSource_HostRequestHeaderOverride_200(t *testing.T) {
 					resource.TestCheckResourceAttr("data.http.http_test", "response_headers.X-Single", "foobar"),
 					resource.TestCheckResourceAttr("data.http.http_test", "response_headers.X-Double", "1, 2"),
 				),
+			},
+		},
+	})
+}
+
+func TestDataSource_WithBasicAuth_200(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		expected := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:secret"))
+		if auth == expected {
+			w.Header().Set("Content-Type", "text/plain")
+			_, err := w.Write([]byte("authenticated"))
+			if err != nil {
+				t.Errorf("error writing body: %s", err)
+			}
+		} else {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer testServer.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url      = "%s"
+								username = "admin"
+								password = "secret"
+							}`, testServer.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "authenticated"),
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_WithBasicAuth_401(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer testServer.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url      = "%s"
+								username = "admin"
+								password = "wrong"
+							}`, testServer.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "401"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_WithBasicAuth_UsernameOnly(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+	}))
+	defer testServer.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url      = "%s"
+								username = "admin"
+							}`, testServer.URL),
+				ExpectError: regexp.MustCompile("Attribute \"password\" must be specified when \"username\" is specified"),
+			},
+		},
+	})
+}
+
+func TestDataSource_WithBasicAuth_PasswordOnly(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+	}))
+	defer testServer.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url      = "%s"
+								password = "secret"
+							}`, testServer.URL),
+				ExpectError: regexp.MustCompile("Attribute \"username\" must be specified when \"password\" is specified"),
 			},
 		},
 	})


### PR DESCRIPTION
## Related Issue

Fixes #51

## Description

Adds dedicated `username` and `password` attributes for HTTP Basic Authentication. When both are set, an `Authorization: Basic <base64>` header is automatically added to the request.

The `password` attribute is marked as sensitive. Both attributes use `AlsoRequires` validation to ensure they are provided together.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
