### PR TITLE
data-source/http: Add protocol_version attribute to select IPv4 or IPv6 (#228)

### DIFF
--- a/.changes/unreleased/issue-228.yaml
+++ b/.changes/unreleased/issue-228.yaml
@@ -1,0 +1,4 @@
+kind: ENHANCEMENTS
+body: 'data-source/http: Adds `protocol_version` attribute to select IPv4 or IPv6'
+custom:
+  Issue: 228

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -101,6 +102,15 @@ a 5xx-range (except 501) status code is received. For further details see
 			"request_body": schema.StringAttribute{
 				Description: "The request body as a string.",
 				Optional:    true,
+			},
+
+			"protocol_version": schema.StringAttribute{
+				Description: "The IP protocol version to use for the request. " +
+					"Valid values are `4` and `6`. Defaults to a system-determined behavior.",
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf([]string{"4", "6"}...),
+				},
 			},
 
 			"request_timeout_ms": schema.Int64Attribute{
@@ -240,6 +250,23 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	// Prevent issues with tests caching the proxy configuration.
 	clonedTr.Proxy = func(req *http.Request) (*url.URL, error) {
 		return httpproxy.FromEnvironment().ProxyFunc()(req.URL)
+	}
+
+	if !model.ProtocolVersion.IsNull() {
+		network := "tcp"
+		switch model.ProtocolVersion.ValueString() {
+		case "4":
+			network = "tcp4"
+		case "6":
+			network = "tcp6"
+		}
+		dialer := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
+		clonedTr.DialContext = func(ctx context.Context, _, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, addr)
+		}
 	}
 
 	if clonedTr.TLSClientConfig == nil {
@@ -433,6 +460,7 @@ type modelV0 struct {
 	ClientCert         types.String `tfsdk:"client_cert_pem"`
 	ClientKey          types.String `tfsdk:"client_key_pem"`
 	Insecure           types.Bool   `tfsdk:"insecure"`
+	ProtocolVersion    types.String `tfsdk:"protocol_version"`
 	ResponseBody       types.String `tfsdk:"response_body"`
 	Body               types.String `tfsdk:"body"`
 	ResponseBodyBase64 types.String `tfsdk:"response_body_base64"`

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -700,6 +700,54 @@ func TestDataSource_HostRequestHeaderOverride_200(t *testing.T) {
 	})
 }
 
+func TestDataSource_ProtocolVersion4(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, err := w.Write([]byte("ipv4-test"))
+		if err != nil {
+			t.Errorf("error writing body: %s", err)
+		}
+	}))
+	defer testServer.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url              = "%s"
+								protocol_version = "4"
+							}`, testServer.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "ipv4-test"),
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_InvalidProtocolVersion(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	defer testServer.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url              = "%s"
+								protocol_version = "3"
+							}`, testServer.URL),
+				ExpectError: regexp.MustCompile(`value must be one of: \["4" "6"\]`),
+			},
+		},
+	})
+}
+
 // testProxiedURL is a hardcoded URL used in acceptance testing where it is
 // expected that a locally started HTTP proxy will handle the request.
 //


### PR DESCRIPTION
## Related Issue

Fixes #228

## Description

Adds `protocol_version` attribute to select IPv4 or IPv6 for HTTP requests. Valid values are `4` and `6`. When unset (default), the system determines the IP version (existing behavior).

The implementation forces the TCP network type to `tcp4` or `tcp6` via a custom `DialContext` on the transport.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
