### PR TITLE
data-source/http: Add request_body_file and request_body_is_base64 attributes (#36)

### DIFF
--- a/.changes/unreleased/issue-36.yaml
+++ b/.changes/unreleased/issue-36.yaml
@@ -1,0 +1,4 @@
+kind: ENHANCEMENTS
+body: 'data-source/http: Adds `request_body_file` and `request_body_is_base64` attributes for file-based and binary request bodies'
+custom:
+  Issue: 36

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -13,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -101,6 +103,17 @@ a 5xx-range (except 501) status code is received. For further details see
 			"request_body": schema.StringAttribute{
 				Description: "The request body as a string.",
 				Optional:    true,
+			},
+
+			"request_body_file": schema.StringAttribute{
+				Description: "The path to a file to use as the request body.",
+				Optional:    true,
+			},
+
+			"request_body_is_base64": schema.BoolAttribute{
+				Description: "Set to true if the `request_body` or `request_body_file` content is base64-encoded. " +
+					"The provider will decode it before sending.",
+				Optional: true,
 			},
 
 			"request_timeout_ms": schema.Int64Attribute{
@@ -323,9 +336,45 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	if !model.RequestBody.IsNull() {
-		err = request.SetBody(strings.NewReader(model.RequestBody.ValueString()))
+	var bodyReader io.Reader
 
+	if !model.RequestBodyFile.IsNull() {
+		data, err := os.ReadFile(model.RequestBodyFile.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error Reading Request Body File",
+				fmt.Sprintf("Error reading request body file: %s", err),
+			)
+			return
+		}
+		bodyReader = bytes.NewReader(data)
+	} else if !model.RequestBody.IsNull() {
+		bodyReader = strings.NewReader(model.RequestBody.ValueString())
+	}
+
+	if bodyReader != nil {
+		if !model.RequestBodyIsBase64.IsNull() && model.RequestBodyIsBase64.ValueBool() {
+			data, err := io.ReadAll(bodyReader)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error Reading Request Body",
+					fmt.Sprintf("Error reading request body: %s", err),
+				)
+				return
+			}
+			decoded := make([]byte, base64.StdEncoding.DecodedLen(len(data)))
+			n, err := base64.StdEncoding.Decode(decoded, data)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error Decoding Base64 Request Body",
+					fmt.Sprintf("Error decoding base64 request body: %s", err),
+				)
+				return
+			}
+			bodyReader = bytes.NewReader(decoded[:n])
+		}
+
+		err = request.SetBody(io.NopCloser(bodyReader))
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Setting Request Body",
@@ -421,22 +470,24 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 }
 
 type modelV0 struct {
-	ID                 types.String `tfsdk:"id"`
-	URL                types.String `tfsdk:"url"`
-	Method             types.String `tfsdk:"method"`
-	RequestHeaders     types.Map    `tfsdk:"request_headers"`
-	RequestBody        types.String `tfsdk:"request_body"`
-	RequestTimeout     types.Int64  `tfsdk:"request_timeout_ms"`
-	Retry              types.Object `tfsdk:"retry"`
-	ResponseHeaders    types.Map    `tfsdk:"response_headers"`
-	CaCertificate      types.String `tfsdk:"ca_cert_pem"`
-	ClientCert         types.String `tfsdk:"client_cert_pem"`
-	ClientKey          types.String `tfsdk:"client_key_pem"`
-	Insecure           types.Bool   `tfsdk:"insecure"`
-	ResponseBody       types.String `tfsdk:"response_body"`
-	Body               types.String `tfsdk:"body"`
-	ResponseBodyBase64 types.String `tfsdk:"response_body_base64"`
-	StatusCode         types.Int64  `tfsdk:"status_code"`
+	ID                  types.String `tfsdk:"id"`
+	URL                 types.String `tfsdk:"url"`
+	Method              types.String `tfsdk:"method"`
+	RequestHeaders      types.Map    `tfsdk:"request_headers"`
+	RequestBody         types.String `tfsdk:"request_body"`
+	RequestBodyFile     types.String `tfsdk:"request_body_file"`
+	RequestBodyIsBase64 types.Bool   `tfsdk:"request_body_is_base64"`
+	RequestTimeout      types.Int64  `tfsdk:"request_timeout_ms"`
+	Retry               types.Object `tfsdk:"retry"`
+	ResponseHeaders     types.Map    `tfsdk:"response_headers"`
+	CaCertificate       types.String `tfsdk:"ca_cert_pem"`
+	ClientCert          types.String `tfsdk:"client_cert_pem"`
+	ClientKey           types.String `tfsdk:"client_key_pem"`
+	Insecure            types.Bool   `tfsdk:"insecure"`
+	ResponseBody        types.String `tfsdk:"response_body"`
+	Body                types.String `tfsdk:"body"`
+	ResponseBodyBase64  types.String `tfsdk:"response_body_base64"`
+	StatusCode          types.Int64  `tfsdk:"status_code"`
 }
 
 type retryModel struct {

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -13,6 +14,8 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -1014,6 +1017,140 @@ func TestDataSource_ResponseBodyBinary(t *testing.T) {
 					// Note the replacement character in the string representation in `response_body`.
 					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "GIF89a\x01\x00\x01\x00�\x00\x00\x00\x00\x00\x00\x00\x00!�\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"),
 					resource.TestCheckResourceAttr("data.http.http_test", "response_body_base64", "R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_RequestBodyFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "body.txt")
+	err := os.WriteFile(tmpFile, []byte("test file body"), 0644)
+	if err != nil {
+		t.Fatalf("error writing temp file: %s", err)
+	}
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if string(requestBody) == "test file body" {
+			_, _ = w.Write([]byte("ok"))
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "http" "test" {
+						url               = "%s"
+						method            = "POST"
+						request_body_file = %q
+					}`, svr.URL, tmpFile),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.test", "status_code", "200"),
+					resource.TestCheckResourceAttr("data.http.test", "response_body", "ok"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_RequestBodyBase64(t *testing.T) {
+	t.Parallel()
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if string(requestBody) == "hello" {
+			_, _ = w.Write([]byte("decoded"))
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "http" "test" {
+						url                    = "%s"
+						method                 = "POST"
+						request_body           = base64encode("hello")
+						request_body_is_base64 = true
+					}`, svr.URL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.test", "status_code", "200"),
+					resource.TestCheckResourceAttr("data.http.test", "response_body", "decoded"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_RequestBodyBase64FromFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	encoded := base64.StdEncoding.EncodeToString([]byte("hello from file"))
+	tmpFile := filepath.Join(tmpDir, "body.b64")
+	err := os.WriteFile(tmpFile, []byte(encoded), 0644)
+	if err != nil {
+		t.Fatalf("error writing temp file: %s", err)
+	}
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if string(requestBody) == "hello from file" {
+			_, _ = w.Write([]byte("file decoded ok"))
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "http" "test" {
+						url                    = "%s"
+						method                 = "POST"
+						request_body_file      = %q
+						request_body_is_base64 = true
+					}`, svr.URL, tmpFile),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.test", "status_code", "200"),
+					resource.TestCheckResourceAttr("data.http.test", "response_body", "file decoded ok"),
 				),
 			},
 		},


### PR DESCRIPTION
## Related Issue

Fixes #36

## Description

Adds two new attributes for more flexible request body handling:

- `request_body_file`: Specifies a file path to use as the request body. Mutually exclusive with `request_body`.
- `request_body_is_base64`: When set to `true`, the provider decodes the base64-encoded body before sending. Works with both `request_body` and `request_body_file`.

This enables binary data upload and file-based request bodies without requiring inline content in the HCL configuration.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
