### PR TITLE
data-source/http: Fix request_timeout_ms being ignored by applying timeout to request context (#402)

### DIFF
--- a/.changes/unreleased/issue-402.yaml
+++ b/.changes/unreleased/issue-402.yaml
@@ -1,0 +1,4 @@
+kind: BUG FIXES
+body: 'data-source/http: Fix `request_timeout_ms` being ignored by applying timeout to request context'
+custom:
+  Issue: 402

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -300,6 +300,10 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	if model.RequestTimeout.ValueInt64() > 0 {
 		timeout = time.Duration(model.RequestTimeout.ValueInt64()) * time.Millisecond
 		retryClient.HTTPClient.Timeout = timeout
+
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
 	}
 
 	retryClient.Logger = levelledLogger{ctx}
@@ -367,6 +371,20 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 				)
 				return
 			}
+		}
+
+		if errors.Is(err, context.DeadlineExceeded) {
+			detail := fmt.Sprintf("timeout error: %s", err)
+
+			if timeout > 0 {
+				detail = fmt.Sprintf("request exceeded the specified timeout: %s, err: %s", timeout.String(), err)
+			}
+
+			resp.Diagnostics.AddError(
+				"Error making request",
+				detail,
+			)
+			return
 		}
 
 		resp.Diagnostics.AddError(

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -759,6 +759,29 @@ func TestDataSource_HTTPViaProxyWithEnv(t *testing.T) {
 	})
 }
 
+func TestDataSource_TimeoutNoTimeout(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+	}))
+	defer svr.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url = "%s"
+								request_timeout_ms = 5000
+							}`, svr.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "200"),
+				),
+			},
+		},
+	})
+}
+
 func TestDataSource_Timeout(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(time.Duration(10) * time.Millisecond)


### PR DESCRIPTION
## Related Issue

Fixes #402

## Description

The `request_timeout_ms` setting was being ignored in some cases because it only set `http.Client.Timeout` without applying the timeout to the request context. When the Terraform plugin framework context had a longer deadline, the underlying `http.Client.Timeout` would race with the context.

This fix creates a new context with the configured timeout using `context.WithTimeout`, ensuring the timeout is properly honored regardless of the parent context's deadline.

The error handling is also updated to catch `context.DeadlineExceeded` errors that may arise from the context-based timeout.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
