### PR TITLE
data-source/http: Downgrade UTF-8 warning to debug log (#286)

### DIFF
--- a/.changes/unreleased/issue-286.yaml
+++ b/.changes/unreleased/issue-286.yaml
@@ -1,0 +1,4 @@
+kind: BUG FIXES
+body: 'data-source/http: Downgrade UTF-8 warning to debug log to prevent noise when using `response_body_base64`'
+custom:
+  Issue: 286

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -388,10 +388,7 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	if !utf8.Valid(bytes) {
-		resp.Diagnostics.AddWarning(
-			"Response body is not recognized as UTF-8",
-			"Terraform may not properly handle the response_body if the contents are binary.",
-		)
+		tflog.Debug(ctx, "Response body is not recognized as UTF-8. Use response_body_base64 for binary data.")
 	}
 
 	responseBody := string(bytes)

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -986,6 +986,30 @@ func TestDataSource_ResponseBodyText(t *testing.T) {
 	})
 }
 
+func TestDataSource_BinaryContentNoWarning(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write([]byte{0x00, 0x01, 0x02, 0xFF})
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url = "%s"
+							}`, svr.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "200"),
+				),
+			},
+		},
+	})
+}
+
 func TestDataSource_ResponseBodyBinary(t *testing.T) {
 	// 1 x 1 transparent gif pixel.
 	const transPixel = "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x21\xF9\x04\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3B"


### PR DESCRIPTION
## Related Issue

Fixes #286

## Description

The UTF-8 warning was shown on every response with non-UTF-8 content, even when the user wasn't using `response_body` directly (e.g., using `response_body_base64` instead). This caused noisy warnings in CI/CD pipelines.

Downgrades the warning from `AddWarning` to `tflog.Debug` so it only appears when `TF_LOG=debug` is set. The `response_body_base64` attribute already provides a safe way to handle binary data.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
