### PR TITLE
data-source/http: Log request and response details on TF_LOG=debug (#395)

### DIFF
--- a/.changes/unreleased/issue-395.yaml
+++ b/.changes/unreleased/issue-395.yaml
@@ -1,0 +1,4 @@
+kind: ENHANCEMENTS
+body: 'data-source/http: Log request and response details when `TF_LOG=debug` is set'
+custom:
+  Issue: 395

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -350,6 +350,11 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		}
 	}
 
+	tflog.Debug(ctx, "Making HTTP request", map[string]interface{}{
+		"method": request.Method,
+		"url":    request.URL.String(),
+	})
+
 	response, err := retryClient.Do(request)
 	if err != nil {
 		target := &url.Error{}
@@ -377,6 +382,10 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	defer response.Body.Close()
+
+	tflog.Debug(ctx, "Received HTTP response", map[string]interface{}{
+		"status_code": response.StatusCode,
+	})
 
 	bytes, err := io.ReadAll(response.Body)
 	if err != nil {

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -1020,6 +1020,39 @@ func TestDataSource_ResponseBodyBinary(t *testing.T) {
 	})
 }
 
+func TestDataSource_RequestResponseLogging(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("X-Custom", "test-value")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("logged"))
+		if err != nil {
+			t.Errorf("error writing body: %s", err)
+		}
+	}))
+	defer testServer.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url = "%s"
+								request_headers = {
+									"X-Test" = "request-header"
+								}
+							}`, testServer.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "200"),
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "logged"),
+					resource.TestCheckResourceAttr("data.http.http_test", "response_headers.X-Custom", "test-value"),
+				),
+			},
+		},
+	})
+}
+
 func checkServerAndProxyRequestCount(proxyRequestCount, serverRequestCount *int) resource.TestCheckFunc {
 	return func(_ *terraform.State) error {
 		if *proxyRequestCount != *serverRequestCount {


### PR DESCRIPTION
## Related Issue

Fixes #395

## Description

Adds debug-level logging of HTTP requests and responses when `TF_LOG=debug` is set. The provider now logs the request method and URL before sending, and the response status code after receiving.

This helps users debug issues with redirects, authentication, or unexpected behavior without requiring server-side logging.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
