### PR TITLE
data-source/http: Add response_is_sensitive and sensitive_response_body attributes (#383)

### DIFF
--- a/.changes/unreleased/issue-383.yaml
+++ b/.changes/unreleased/issue-383.yaml
@@ -1,0 +1,4 @@
+kind: ENHANCEMENTS
+body: 'data-source/http: Add `response_is_sensitive` and `sensitive_response_body` attributes for marking response as sensitive'
+custom:
+  Issue: 383

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -111,6 +111,19 @@ a 5xx-range (except 501) status code is received. For further details see
 				},
 			},
 
+			"response_is_sensitive": schema.BoolAttribute{
+				Description: "Mark the response data as sensitive. When true, the response body is also " +
+					"available in `sensitive_response_body` which is marked as sensitive in the Terraform state.",
+				Optional: true,
+			},
+
+			"sensitive_response_body": schema.StringAttribute{
+				Description: "The response body returned as a sensitive string. " +
+					"Populated when `response_is_sensitive` is set to `true`.",
+				Computed:  true,
+				Sensitive: true,
+			},
+
 			"response_body": schema.StringAttribute{
 				Description: "The response body returned as a string.",
 				Computed:    true,
@@ -416,27 +429,33 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	model.ResponseBodyBase64 = types.StringValue(responseBodyBase64Std)
 	model.StatusCode = types.Int64Value(int64(response.StatusCode))
 
+	if !model.ResponseIsSensitive.IsNull() && model.ResponseIsSensitive.ValueBool() {
+		model.SensitiveResponseBody = types.StringValue(responseBody)
+	}
+
 	diags = resp.State.Set(ctx, model)
 	resp.Diagnostics.Append(diags...)
 }
 
 type modelV0 struct {
-	ID                 types.String `tfsdk:"id"`
-	URL                types.String `tfsdk:"url"`
-	Method             types.String `tfsdk:"method"`
-	RequestHeaders     types.Map    `tfsdk:"request_headers"`
-	RequestBody        types.String `tfsdk:"request_body"`
-	RequestTimeout     types.Int64  `tfsdk:"request_timeout_ms"`
-	Retry              types.Object `tfsdk:"retry"`
-	ResponseHeaders    types.Map    `tfsdk:"response_headers"`
-	CaCertificate      types.String `tfsdk:"ca_cert_pem"`
-	ClientCert         types.String `tfsdk:"client_cert_pem"`
-	ClientKey          types.String `tfsdk:"client_key_pem"`
-	Insecure           types.Bool   `tfsdk:"insecure"`
-	ResponseBody       types.String `tfsdk:"response_body"`
-	Body               types.String `tfsdk:"body"`
-	ResponseBodyBase64 types.String `tfsdk:"response_body_base64"`
-	StatusCode         types.Int64  `tfsdk:"status_code"`
+	ID                    types.String `tfsdk:"id"`
+	URL                   types.String `tfsdk:"url"`
+	Method                types.String `tfsdk:"method"`
+	RequestHeaders        types.Map    `tfsdk:"request_headers"`
+	RequestBody           types.String `tfsdk:"request_body"`
+	RequestTimeout        types.Int64  `tfsdk:"request_timeout_ms"`
+	Retry                 types.Object `tfsdk:"retry"`
+	ResponseHeaders       types.Map    `tfsdk:"response_headers"`
+	CaCertificate         types.String `tfsdk:"ca_cert_pem"`
+	ClientCert            types.String `tfsdk:"client_cert_pem"`
+	ClientKey             types.String `tfsdk:"client_key_pem"`
+	Insecure              types.Bool   `tfsdk:"insecure"`
+	ResponseIsSensitive   types.Bool   `tfsdk:"response_is_sensitive"`
+	SensitiveResponseBody types.String `tfsdk:"sensitive_response_body"`
+	ResponseBody          types.String `tfsdk:"response_body"`
+	Body                  types.String `tfsdk:"body"`
+	ResponseBodyBase64    types.String `tfsdk:"response_body_base64"`
+	StatusCode            types.Int64  `tfsdk:"status_code"`
 }
 
 type retryModel struct {

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -1020,6 +1020,62 @@ func TestDataSource_ResponseBodyBinary(t *testing.T) {
 	})
 }
 
+func TestDataSource_ResponseIsSensitive(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, err := w.Write([]byte("sensitive-data"))
+		if err != nil {
+			t.Errorf("error writing body: %s", err)
+		}
+	}))
+	defer testServer.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url = "%s"
+								response_is_sensitive = true
+							}`, testServer.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "sensitive-data"),
+					resource.TestCheckResourceAttr("data.http.http_test", "sensitive_response_body", "sensitive-data"),
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSource_ResponseIsNotSensitive(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, err := w.Write([]byte("public-data"))
+		if err != nil {
+			t.Errorf("error writing body: %s", err)
+		}
+	}))
+	defer testServer.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url = "%s"
+							}`, testServer.URL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "response_body", "public-data"),
+					resource.TestCheckNoResourceAttr("data.http.http_test", "sensitive_response_body"),
+				),
+			},
+		},
+	})
+}
+
 func checkServerAndProxyRequestCount(proxyRequestCount, serverRequestCount *int) resource.TestCheckFunc {
 	return func(_ *terraform.State) error {
 		if *proxyRequestCount != *serverRequestCount {


### PR DESCRIPTION
## Related Issue

Fixes #383

## Description

Adds `response_is_sensitive` boolean attribute and `sensitive_response_body` computed+sensitive attribute. When `response_is_sensitive = true` is set, the response body is also made available in `sensitive_response_body`, which is marked as sensitive in the Terraform state and will not appear in logs or plaintext output.

The regular `response_body` is still populated for backward compatibility, but users should reference `sensitive_response_body` when sensitive data is expected.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
