### PR TITLE
data-source/http: Add location_trusted attribute to forward headers on redirects (#396)

### DIFF
--- a/.changes/unreleased/issue-396.yaml
+++ b/.changes/unreleased/issue-396.yaml
@@ -1,0 +1,4 @@
+kind: ENHANCEMENTS
+body: 'data-source/http: Add `location_trusted` attribute to forward headers on HTTP redirects'
+custom:
+  Issue: 396

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -160,6 +160,12 @@ a 5xx-range (except 501) status code is received. For further details see
 				Optional:    true,
 			},
 
+			"location_trusted": schema.BoolAttribute{
+				Description: "Set to `true` to forward all request headers (including Authorization) on redirects. " +
+					"Use with caution: this may expose sensitive headers to untrusted servers. Defaults to `false`.",
+				Optional: true,
+			},
+
 			"response_headers": schema.MapAttribute{
 				Description: `A map of response header field names and values.` +
 					` Duplicate headers are concatenated according to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).`,
@@ -294,6 +300,19 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	retryClient := retryablehttp.NewClient()
 	retryClient.HTTPClient.Transport = clonedTr
+
+	if !model.LocationTrusted.IsNull() && model.LocationTrusted.ValueBool() {
+		retryClient.HTTPClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return http.ErrUseLastResponse
+			}
+			// Forward all headers from the original request on redirect
+			for k, v := range via[0].Header {
+				req.Header[k] = v
+			}
+			return nil
+		}
+	}
 
 	var timeout time.Duration
 
@@ -433,6 +452,7 @@ type modelV0 struct {
 	ClientCert         types.String `tfsdk:"client_cert_pem"`
 	ClientKey          types.String `tfsdk:"client_key_pem"`
 	Insecure           types.Bool   `tfsdk:"insecure"`
+	LocationTrusted    types.Bool   `tfsdk:"location_trusted"`
 	ResponseBody       types.String `tfsdk:"response_body"`
 	Body               types.String `tfsdk:"body"`
 	ResponseBodyBase64 types.String `tfsdk:"response_body_base64"`

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -1020,6 +1020,49 @@ func TestDataSource_ResponseBodyBinary(t *testing.T) {
 	})
 }
 
+func TestDataSource_LocationTrusted_HeaderForwarded(t *testing.T) {
+	var authHeader string
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "text/plain")
+		_, err := w.Write([]byte("ok"))
+		if err != nil {
+			t.Errorf("error writing body: %s", err)
+		}
+	}))
+	defer testServer.Close()
+
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, testServer.URL, http.StatusFound)
+	}))
+	defer redirectServer.Close()
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+							data "http" "http_test" {
+								url = "%s"
+								location_trusted = true
+								request_headers = {
+									Authorization = "Bearer test-token"
+								}
+							}`, redirectServer.URL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.http_test", "status_code", "200"),
+					func(_ *terraform.State) error {
+						if authHeader != "Bearer test-token" {
+							return fmt.Errorf("expected Authorization header to be forwarded, got: %s", authHeader)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func checkServerAndProxyRequestCount(proxyRequestCount, serverRequestCount *int) resource.TestCheckFunc {
 	return func(_ *terraform.State) error {
 		if *proxyRequestCount != *serverRequestCount {


### PR DESCRIPTION
## Related Issue

Fixes #396

## Description

Go's `http.Client` strips sensitive headers (like `Authorization`) on cross-origin redirects by default. This is correct for most cases, but some APIs redirect to a different instance with the same trusted domain.

Adds `location_trusted` boolean attribute. When set to `true`, all request headers from the original request are forwarded on HTTP redirects. Defaults to `false` for security.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

- When `location_trusted = true`, Authorization headers may be forwarded to the redirect target. Users should only enable this when the redirect target is trusted.
