### PR TITLE
data-source/http: Add retry.max_http_status attribute for 4xx retry support (#584)

### DIFF
--- a/.changes/unreleased/issue-584.yaml
+++ b/.changes/unreleased/issue-584.yaml
@@ -1,0 +1,4 @@
+kind: ENHANCEMENTS
+body: 'data-source/http: Add `retry.max_http_status` attribute to enable retry on 4xx status codes'
+custom:
+  Issue: 584

--- a/internal/provider/data_source_http.go
+++ b/internal/provider/data_source_http.go
@@ -201,6 +201,15 @@ a 5xx-range (except 501) status code is received. For further details see
 							int64validator.AtLeastSumOf(path.MatchRelative().AtParent().AtName("min_delay_ms")),
 						},
 					},
+					"max_http_status": schema.Int64Attribute{
+						Description: "The maximum HTTP status code to retry on. " +
+							"For example, if set to 499, any status code between 400 and 499 will trigger a retry. " +
+							"Setting this to a value less than 500 extends the default 5xx retry behavior to include 4xx responses.",
+						Optional: true,
+						Validators: []validator.Int64{
+							int64validator.Between(400, 599),
+						},
+					},
 				},
 			},
 		},
@@ -304,6 +313,34 @@ func (d *httpDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	retryClient.Logger = levelledLogger{ctx}
 	retryClient.RetryMax = int(retry.Attempts.ValueInt64())
+
+	if !retry.MaxHTTPStatus.IsNull() && !retry.MaxHTTPStatus.IsUnknown() {
+		maxStatus := int(retry.MaxHTTPStatus.ValueInt64())
+		retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+			if ctx.Err() != nil {
+				return false, ctx.Err()
+			}
+
+			if err != nil {
+				// The error is likely recoverable so retry.
+				return true, nil //nolint:nilerr // matches retryablehttp.DefaultRetryPolicy behavior
+			}
+
+			if resp.StatusCode == http.StatusTooManyRequests {
+				return true, nil
+			}
+
+			if resp.StatusCode >= 500 && resp.StatusCode != http.StatusNotImplemented {
+				return true, nil
+			}
+
+			if resp.StatusCode >= 400 && resp.StatusCode <= maxStatus {
+				return true, nil
+			}
+
+			return false, nil
+		}
+	}
 
 	if !retry.MinDelay.IsNull() && !retry.MinDelay.IsUnknown() && retry.MinDelay.ValueInt64() >= 0 {
 		retryClient.RetryWaitMin = time.Duration(retry.MinDelay.ValueInt64()) * time.Millisecond
@@ -440,9 +477,10 @@ type modelV0 struct {
 }
 
 type retryModel struct {
-	Attempts types.Int64 `tfsdk:"attempts"`
-	MinDelay types.Int64 `tfsdk:"min_delay_ms"`
-	MaxDelay types.Int64 `tfsdk:"max_delay_ms"`
+	Attempts      types.Int64 `tfsdk:"attempts"`
+	MinDelay      types.Int64 `tfsdk:"min_delay_ms"`
+	MaxDelay      types.Int64 `tfsdk:"max_delay_ms"`
+	MaxHTTPStatus types.Int64 `tfsdk:"max_http_status"`
 }
 
 var _ retryablehttp.LeveledLogger = levelledLogger{}

--- a/internal/provider/data_source_http_test.go
+++ b/internal/provider/data_source_http_test.go
@@ -1020,6 +1020,47 @@ func TestDataSource_ResponseBodyBinary(t *testing.T) {
 	})
 }
 
+func TestDataSource_RetryOn4xx(t *testing.T) {
+	var requestCount int
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "text/plain")
+		if requestCount < 2 {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("retried"))
+		}
+	}))
+	defer svr.Close()
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "http" "test" {
+						url = "%s"
+						retry {
+							attempts = 1
+							max_http_status = 499
+						}
+					}`, svr.URL),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.http.test", "status_code", "200"),
+					resource.TestCheckResourceAttr("data.http.test", "response_body", "retried"),
+					func(_ *terraform.State) error {
+						if requestCount < 2 {
+							return fmt.Errorf("expected at least 2 requests (retry on 404), got %d", requestCount)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func checkServerAndProxyRequestCount(proxyRequestCount, serverRequestCount *int) resource.TestCheckFunc {
 	return func(_ *terraform.State) error {
 		if *proxyRequestCount != *serverRequestCount {


### PR DESCRIPTION
## Related Issue

Fixes #584

## Description

The default retry policy only retries on 5xx (except 501) and 429 status codes. This adds `retry.max_http_status` attribute to extend retry behavior to 4xx status codes.

When `max_http_status` is set to a value between 400-599, any HTTP status code >= 400 and <= `max_http_status` will trigger a retry. For example, `max_http_status = 499` retries on 404, 429, 499, etc.

This is useful when waiting for an endpoint to become available (e.g., deploying a service that initially returns 404).

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
